### PR TITLE
Fixed Magento 2.4.4: Missed required argument deploymentConfig

### DIFF
--- a/Module/Plugin/SoftDbStatusValidator.php
+++ b/Module/Plugin/SoftDbStatusValidator.php
@@ -2,7 +2,7 @@
 
 namespace MageSuite\SoftDbStatusValidation\Module\Plugin;
 
-
+use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\FrontController;
 use Magento\Framework\App\RequestInterface;
 
@@ -24,13 +24,14 @@ class SoftDbStatusValidator extends \Magento\Framework\Module\Plugin\DbStatusVal
     private $appState;
 
     public function __construct(
+        DeploymentConfig $deploymentConfig,
         \Magento\Framework\Cache\FrontendInterface $cache,
         \Magento\Framework\Module\DbVersionInfo $dbVersionInfo,
         \MageSuite\SoftDbStatusValidation\Model\Config $config,
         \Magento\Framework\App\State $appState,
         \Psr\Log\LoggerInterface $logger
     ) {
-        parent::__construct($cache, $dbVersionInfo);
+        parent::__construct($cache, $dbVersionInfo, $deploymentConfig);
 
         $this->config = $config;
         $this->logger = $logger;


### PR DESCRIPTION
```
Errors during compilation:
        MageSuite\SoftDbStatusValidation\Module\Plugin\SoftDbStatusValidator
                Missed required argument deploymentConfig in parent::__construct call. File: /var/www/magento-244/vendor/creativestyle/magesuite-soft-db-status-validation/Module/Plugin/SoftDbStatusValidator.php
```